### PR TITLE
Remove the use of isRecVariable at update_op_coords

### DIFF
--- a/pylops/waveeqprocessing/twoway.py
+++ b/pylops/waveeqprocessing/twoway.py
@@ -327,14 +327,13 @@ class _Wave(LinearOperator):
         sx, sz = src_coords
 
         nrec = len(rx)
-        dims_update = self.segyReader.isRecVariable and nrec != self.geometry.nrec
-
-        self._update_geometry(rx, rz, sx, sz, nrec)
 
         # Check if the number of receivers is variable and differs from the current geometry.
         # If so, update the dimensions to match the new number of receivers for the current shot.
-        if dims_update:
+        if nrec != self.geometry.nrec:
             self._update_dimensions(new_dims=self.dims, new_dimsd=(1, nrec, self.geometry.nt))
+
+        self._update_geometry(rx, rz, sx, sz, nrec)
 
     def resample(self, data, num):
         nshots, ntraces, nsteps = data.shape


### PR DESCRIPTION
In the previous version, if the number of receivers was not variable, it would never be updated and would remain at its initial value. This is not the desired behavior