### PR TITLE
Custom fields for ReadSEGY3D

### DIFF
--- a/pylops/waveeqprocessing/segy.py
+++ b/pylops/waveeqprocessing/segy.py
@@ -32,7 +32,6 @@ def get_velocity_model(model_path):
     return vp, dims
 
 
-
 class SegyDict(dict):
     
     DEFAULT_FIELDS = {
@@ -173,9 +172,11 @@ class ReadSEGY2D():
                     lookup_table[index]['Num_Traces'] = 1
                     lookup_table[index]['Source'] = (header[segyio.TraceField.SourceX] * scalco, header[segyio.TraceField.SourceY] * scalco)
                     lookup_table[index]['Receivers'] = []
+                    lookup_table[index]['scalcos'] = []
                 else:  # Not in a new shot, so increase the number of traces in the shot by 1
                     lookup_table[index]['Num_Traces'] += 1
                 lookup_table[index]['Receivers'].append((header[segyio.TraceField.GroupX] * scalco, header[segyio.TraceField.GroupY] * scalco))
+                lookup_table[index]['scalcos'].append(scalco)
                 pos_in_file += 1
 
         return lookup_table, indexes

--- a/pylops/waveeqprocessing/segy.py
+++ b/pylops/waveeqprocessing/segy.py
@@ -1,5 +1,5 @@
 import segyio
-
+import warnings
 import numpy as np
 
 
@@ -30,6 +30,83 @@ def get_velocity_model(model_path):
 
     vp = f.trace.raw[:].reshape(dims)
     return vp, dims
+
+
+
+class SegyDict(dict):
+    
+    DEFAULT_FIELDS = {
+        "shot_id": segyio.TraceField.FieldRecord,
+        "source_x": segyio.TraceField.SourceX,
+        "source_y": segyio.TraceField.SourceY,
+        "source_z": segyio.TraceField.SourceSurfaceElevation,
+        "rec_x": segyio.TraceField.GroupX,
+        "rec_y": segyio.TraceField.GroupY,
+        "rec_z": segyio.TraceField.ReceiverGroupElevation,
+        "scalco": segyio.TraceField.SourceGroupScalar
+    }
+    ALLOWED_KEYS = set(DEFAULT_FIELDS.keys())
+    
+    def __init__(self, input_dict=None):
+        super().__init__(self.DEFAULT_FIELDS)
+        
+        if input_dict is not None:
+            self._populate_from_dict(input_dict)
+    
+    def _populate_from_dict(self, input_dict):
+        """
+        Populates the instance from a user provided dict
+        
+        Args:
+            input_dict (dict): source dict to populate
+        """
+        
+        if not isinstance(input_dict, dict):
+            raise TypeError(f"ReadSEGY: expecting a dict for segy_fields, but got {type(input_dict).__name__} instead")
+        
+        for key, value in input_dict.items():
+            if key not in self.ALLOWED_KEYS:
+                warnings.warn(
+                    f"Key '{key}' will be ignored. "
+                    f"Allowed keys: {sorted(self.ALLOWED_KEYS)}",
+                    UserWarning,
+                    stacklevel=2
+                )
+                continue
+            
+            if key not in self:
+                self[key] = value
+    
+    def update(self, other=None, **kwargs):
+        """
+        Keep class restrictions.
+        """
+        if other is not None:
+            self._populate_from_dict(other)
+        if kwargs:
+            self._populate_from_dict(kwargs)
+    
+    def __setitem__(self, key, value):
+        """
+        Keep class restrictions.
+        """
+        if key not in self.ALLOWED_KEYS:
+            raise KeyError(
+                f"Key '{key}' not allowed. "
+                f"Allowed keys: {sorted(self.ALLOWED_KEYS)}"
+            )
+        super().__setitem__(key, value)
+    
+    def setdefault(self, key, default=None):
+        """
+        Keep class restrictions.
+        """
+        if key not in self.ALLOWED_KEYS:
+            raise KeyError(
+                f"Key '{key}' not allowed. "
+                f"Allowed keys: {sorted(self.ALLOWED_KEYS)}"
+            )
+        return super().setdefault(key, default)
 
 
 class ReadSEGY2D():
@@ -189,15 +266,15 @@ class ReadSEGY2D():
 
 class ReadSEGY3D():
 
-    def __init__(self, segy_path, mpi=None, shot_ids=None):
+    def __init__(self, segy_path, mpi=None, shot_ids=None, segy_fields={}):
 
         self.segyfile = segy_path
         self.controller = mpi
-        self.table, self.indexes = self.make_lookup_table(segy_path, mpi, shot_ids)
+        self.table, self.indexes = self.make_lookup_table(segy_path, mpi, shot_ids, segy_fields)
         self.isRecVariable = self._isRecVariable()
         self.nsrc = len(self.table)
 
-    def make_lookup_table(self, sgy_file, mpi_controller, sampled_ids):
+    def make_lookup_table(self, sgy_file, mpi_controller, sampled_ids, segy_fields):
         '''
         Make a lookup of shots, where the keys are the shot record IDs being
         searched (looked up)
@@ -208,22 +285,24 @@ class ReadSEGY3D():
         lookup_table = {}
 
         samples = sampled_ids if not mpi_controller else mpi_controller.shot_ids
+        
+        target_fields = SegyDict(input_dict=segy_fields)
 
         with segyio.open(sgy_file, ignore_geometry=True) as f:
             index = None
             pos_in_file = 0
 
             for header in f.header:
-                index = header[segyio.TraceField.FieldRecord]
+                index = header[target_fields["shot_id"]]
 
                 if (samples and (index not in samples)):
                     pos_in_file += 1
                     continue
 
-                if int(header[segyio.TraceField.SourceGroupScalar]) < 0:
-                    scalco = abs(1. / header[segyio.TraceField.SourceGroupScalar])
+                if int(header[target_fields["scalco"]]) < 0:
+                    scalco = abs(1. / header[target_fields["scalco"]])
                 else:
-                    scalco = header[segyio.TraceField.SourceGroupScalar]
+                    scalco = header[target_fields["scalco"]]
                 # Esses comentários são temporários, scalel voltará a ser utilizado
                 # if int(header[segyio.TraceField.ElevationScalar]) < 0:
                 #     scalel = abs(1. / header[segyio.TraceField.ElevationScalar])
@@ -237,17 +316,17 @@ class ReadSEGY3D():
                     lookup_table[index]['filename'] = sgy_file
                     lookup_table[index]['Trace_Position'] = pos_in_file
                     lookup_table[index]['Num_Traces'] = 1
-                    lookup_table[index]['Source'] = (header[segyio.TraceField.SourceX] * scalco,
-                                                     header[segyio.TraceField.SourceY] * scalco,
-                                                     header[segyio.TraceField.SourceSurfaceElevation] * scalco)
+                    lookup_table[index]['Source'] = (header[target_fields["source_x"]] * scalco,
+                                                     header[target_fields["source_y"]] * scalco,
+                                                     header[target_fields["source_z"]] * scalco)
                     lookup_table[index]['Receivers'] = []
                     lookup_table[index]['scalcos'] = []
                 else:  # Not in a new shot, so increase the number of traces in the shot by 1
                     lookup_table[index]['Num_Traces'] += 1
 
-                lookup_table[index]['Receivers'].append((header[segyio.TraceField.GroupX] * scalco,
-                                                         header[segyio.TraceField.GroupY] * scalco,
-                                                         header[segyio.TraceField.ReceiverGroupElevation] * scalco))
+                lookup_table[index]['Receivers'].append((header[target_fields["rec_x"]] * scalco,
+                                                         header[target_fields["rec_y"]] * scalco,
+                                                         header[target_fields["rec_z"]] * scalco))
                 lookup_table[index]['scalcos'].append(scalco)
                 pos_in_file += 1
 
@@ -278,7 +357,6 @@ class ReadSEGY3D():
         rx = np.array([coord[0] for coord in recs_coords])
         ry = np.array([coord[1] for coord in recs_coords])
         rz = np.array([coord[-1] for coord in recs_coords])
-
         return rx, ry, rz
 
     def getCoords(self, index=0):

--- a/pylops/waveeqprocessing/segy.py
+++ b/pylops/waveeqprocessing/segy.py
@@ -110,11 +110,11 @@ class SegyDict(dict):
 
 class ReadSEGY2D():
 
-    def __init__(self, segy_path, mpi=None, shot_ids=None):
+    def __init__(self, segy_path, mpi=None, shot_ids=None, segy_fields={}):
 
         self.segyfile = segy_path
         self.controller = mpi
-        self.table, self.indexes = self.make_lookup_table(segy_path, mpi, shot_ids)
+        self.table, self.indexes = self.make_lookup_table(segy_path, mpi, shot_ids, segy_fields)
         self.isRecVariable = self._isRecVariable()
         self.nsrc = len(self.table)
 
@@ -130,7 +130,7 @@ class ReadSEGY2D():
         # If the lenght of the set is 1, means that all the shots has the same number os receivers
         return len(n_traces_per_shots) != 1
 
-    def make_lookup_table(self, sgy_file, mpi_controller, sampled_ids):
+    def make_lookup_table(self, sgy_file, mpi_controller, sampled_ids, segy_fields):
         '''
         Make a lookup of shots, where the keys are the shot record IDs being
         searched (looked up)
@@ -141,22 +141,23 @@ class ReadSEGY2D():
         lookup_table = {}
 
         samples = sampled_ids if not mpi_controller else mpi_controller.shot_ids
-
+        target_fields = SegyDict(input_dict=segy_fields)
+        
         with segyio.open(sgy_file, ignore_geometry=True) as f:
             index = None
             pos_in_file = 0
 
             for header in f.header:
-                index = header[segyio.TraceField.FieldRecord]
+                index = header[target_fields["shot_id"]]
 
                 if (samples and (index not in samples)):
                     pos_in_file += 1
                     continue
 
-                if int(header[segyio.TraceField.SourceGroupScalar]) < 0:
-                    scalco = abs(1. / header[segyio.TraceField.SourceGroupScalar])
+                if int(header[target_fields["scalco"]]) < 0:
+                    scalco = abs(1. / header[target_fields["scalco"]])
                 else:
-                    scalco = header[segyio.TraceField.SourceGroupScalar]
+                    scalco = header[target_fields["scalco"]]
                 # Esses comentários são temporários, scalel voltará a ser utilizado
                 # if int(header[segyio.TraceField.ElevationScalar]) < 0:
                 #     scalel = abs(1. / header[segyio.TraceField.ElevationScalar])
@@ -170,12 +171,14 @@ class ReadSEGY2D():
                     lookup_table[index]['filename'] = sgy_file
                     lookup_table[index]['Trace_Position'] = pos_in_file
                     lookup_table[index]['Num_Traces'] = 1
-                    lookup_table[index]['Source'] = (header[segyio.TraceField.SourceX] * scalco, header[segyio.TraceField.SourceY] * scalco)
+                    lookup_table[index]['Source'] = (header[target_fields["source_x"]] * scalco,
+                                                     header[target_fields["source_y"]] * scalco)
                     lookup_table[index]['Receivers'] = []
                     lookup_table[index]['scalcos'] = []
                 else:  # Not in a new shot, so increase the number of traces in the shot by 1
                     lookup_table[index]['Num_Traces'] += 1
-                lookup_table[index]['Receivers'].append((header[segyio.TraceField.GroupX] * scalco, header[segyio.TraceField.GroupY] * scalco))
+                lookup_table[index]['Receivers'].append((header[target_fields["rec_x"]] * scalco,
+                                                         header[target_fields["rec_y"]] * scalco))
                 lookup_table[index]['scalcos'].append(scalco)
                 pos_in_file += 1
 
@@ -286,7 +289,6 @@ class ReadSEGY3D():
         lookup_table = {}
 
         samples = sampled_ids if not mpi_controller else mpi_controller.shot_ids
-        
         target_fields = SegyDict(input_dict=segy_fields)
 
         with segyio.open(sgy_file, ignore_geometry=True) as f:

--- a/pylops/waveeqprocessing/waveequations/acousticwave.py
+++ b/pylops/waveeqprocessing/waveequations/acousticwave.py
@@ -103,6 +103,7 @@ class _AcousticWave(_Wave):
         segy_path: str = None,
         segy_mpi: MPIComm = None,
         segy_sample: Union[int, float] = None,
+        segy_fields: dict = {},
         mpi_instant_reduce: bool = False,
         dswap: bool = False,
         dswap_disks: int = 1,
@@ -165,6 +166,7 @@ class _AcousticWave(_Wave):
                 segy_path,
                 mpi=getattr(self, "mpi_controller", None),
                 shot_ids=sampled_sids,
+                segy_fields=segy_fields
             )
 
         self.instant_reduce = mpi_instant_reduce

--- a/pylops/waveeqprocessing/waveequations/viscoacousticwave.py
+++ b/pylops/waveeqprocessing/waveequations/viscoacousticwave.py
@@ -129,6 +129,7 @@ class _ViscoAcousticWave(_Wave):
         segy_path: str = None,
         segy_mpi: MPIComm = None,
         segy_sample: Union[int, float] = None,
+        segy_fields: dict = {},
         mpi_instant_reduce: bool = False,
     ) -> None:
         if devito_message is not None:
@@ -184,7 +185,8 @@ class _ViscoAcousticWave(_Wave):
             self.segyReader = SegyReader(
                 segy_path,
                 mpi=getattr(self, "mpi_controller", None),
-                shot_ids=sampled_sids
+                shot_ids=sampled_sids,
+                segy_fields=segy_fields
             )
 
         self.instant_reduce = mpi_instant_reduce


### PR DESCRIPTION
Provides to final user the customization of SEGY fields used in the ReadSEGY3D class.
For that, the user only needs to pass a dict to the new _segy_fields_ parameter during the operador creation.
If no dict is provided, default values will be used.
